### PR TITLE
Update condition to check channel connection

### DIFF
--- a/Channel/Sources/EDOSocketChannel.m
+++ b/Channel/Sources/EDOSocketChannel.m
@@ -237,8 +237,8 @@ static dispatch_data_t BuildFrameFromDataWithQueue(NSData *data, dispatch_queue_
       self.remainingDataSize = payloadSize;
       dispatch_io_read(channel, 0, payloadSize, self.eventQueue, dataHandler);
     } else {
-      // Close the channel on errors.
-      if (error != 0) {
+      // Close the channel on errors and closed sockets.
+      if (error != 0 || payloadSize == 0) {
         [self invalidate];
       }
 


### PR DESCRIPTION
If payload size is 0 in frameHandler, it indicates the channel is disconnected.