### PR TITLE
Resolve dummy block miss usage

### DIFF
--- a/Service/Sources/EDOHostService.m
+++ b/Service/Sources/EDOHostService.m
@@ -149,7 +149,11 @@ static const char *gServiceKey = "com.google.edo.servicekey";
     EDOObjectAliveResponse *response =
         (EDOObjectAliveResponse *)[EDOClientService sendRequest:request
                                                            port:object.servicePort.port];
-    return (__bridge id)(void *)response.object.remoteAddress;
+                                                           EDOObject *reponseObject = response.object;
+    if ([EDOBlockObject isBlock:reponseObject]) {
+      reponseObject = [EDOBlockObject EDOBlockObjectFromBlock:reponseObject];
+    }
+    return (__bridge id)(void *)reponseObject.remoteAddress;
   } @catch (NSException *e) {
     // In case of the service is dead or error, ignore the exception and reset to nil.
     // TODO(haowoo): Convert the exception to NSError.

--- a/Service/Sources/EDOObjectAliveMessage.m
+++ b/Service/Sources/EDOObjectAliveMessage.m
@@ -16,7 +16,7 @@
 
 #import "Service/Sources/EDOObjectAliveMessage.h"
 
-#import "third_party/objective_c/eDistantObject/Service/Sources/EDOBlockObject.h"
+#import "Service/Sources/EDOBlockObject.h"
 #import "Service/Sources/EDOHostService+Private.h"
 
 static NSString *const kEDOObjectAliveCoderObjectKey = @"object";

--- a/Service/Sources/EDOObjectAliveMessage.m
+++ b/Service/Sources/EDOObjectAliveMessage.m
@@ -16,6 +16,7 @@
 
 #import "Service/Sources/EDOObjectAliveMessage.h"
 
+#import "third_party/objective_c/eDistantObject/Service/Sources/EDOBlockObject.h"
 #import "Service/Sources/EDOHostService+Private.h"
 
 static NSString *const kEDOObjectAliveCoderObjectKey = @"object";
@@ -56,6 +57,9 @@ static NSString *const kEDOObjectAliveCoderObjectKey = @"object";
   return ^(EDOServiceRequest *request, EDOHostService *service) {
     EDOObjectAliveRequest *retainRequest = (EDOObjectAliveRequest *)request;
     EDOObject *object = retainRequest.object;
+    if ([EDOBlockObject isBlock:object]) {
+      object = [EDOBlockObject EDOBlockObjectFromBlock:object];
+    }
     object = [service isObjectAlive:object] ? object : nil;
     return [EDOObjectAliveResponse responseWithObject:object forRequest:request];
   };


### PR DESCRIPTION
Fix a problem that dummy block is treated as EDOBlockObject in some places. This causes a block cannot be resolved as the same object when corresponding EDOBlockObject comes back from different session for decoding.

Add the test case that will capture this problem.