### PR TITLE
Adding @escaping - the newer swift compiler (Xcode 10) seeing it as t…

### DIFF
--- a/Service/Tests/TestsBundle/EDOTestSwiftClass.swift
+++ b/Service/Tests/TestsBundle/EDOTestSwiftClass.swift
@@ -22,7 +22,7 @@ public class EDOTestSwiftClass : NSObject, EDOTestSwiftProtocol {
     return "Swift String"
   }
 
-  public func returnWithBlock(block: (NSString) -> EDOTestSwiftProtocol) -> NSString {
+  public func returnWithBlock(block: @escaping (NSString) -> EDOTestSwiftProtocol) -> NSString {
     return block("Block").returnString().appending("Block") as NSString
   }
 

--- a/Service/Tests/TestsBundle/EDOTestSwiftProtocol.swift
+++ b/Service/Tests/TestsBundle/EDOTestSwiftProtocol.swift
@@ -20,7 +20,7 @@ import Foundation
 @objc
 public protocol EDOTestSwiftProtocol {
   func returnString() -> NSString
-  func returnWithBlock(block: (NSString) -> EDOTestSwiftProtocol) -> NSString
+  func returnWithBlock(block: @escaping (NSString) -> EDOTestSwiftProtocol) -> NSString
 }
 
 @objc

--- a/docs/swift.md
+++ b/docs/swift.md
@@ -77,4 +77,9 @@ remote.remoteFoo()
 ```
 
 Here the `unsafeCast` lets the compiler know the `AlreadyStubbedClass` has the
-extension.
+extension. Working example is shown
+[here](../Service/Tests/FunctionalTests/EDOSwiftUITest.swift).
+
+### The block closure
+
+The block is also supported but it may confuse the compiler and the runtime as the calling convention can be different. Adding @escaping to let both the runtime and the compiler to know how to handle the block scope. [For example](../Service/Tests/TestsBundle/EDOTestSwiftProtocol.swift).


### PR DESCRIPTION
…he block is invoked outside the function scope if it's in obj-c, or invoked in an obj-c manner.

PiperOrigin-RevId: 213692326