### PR TITLE
Add type to most array, set and dictionarry

### DIFF
--- a/Channel/Tests/EDOChannelPoolTest.m
+++ b/Channel/Tests/EDOChannelPoolTest.m
@@ -56,7 +56,7 @@
 
   for (int i = 0; i < 10; i++) {
     UInt16 port = i % 2 == 0 ? host1.socketPort.port : host2.socketPort.port;
-    NSMutableSet *set = i % 2 == 0 ? set1 : set2;
+    NSMutableSet<EDOSocketChannel *> *set = i % 2 == 0 ? set1 : set2;
     EDOHostPort *hostPort = [EDOHostPort hostPortWithLocalPort:port];
     id<EDOChannel> socketChannel = [channelPool channelWithPort:hostPort error:nil];
 

--- a/Device/Sources/EDODeviceConnector.m
+++ b/Device/Sources/EDODeviceConnector.m
@@ -35,7 +35,7 @@ static const int64_t kDeviceDetectTime = 2;
 /** The detector to detect iOS device attachment/detachment events. */
 @property(nonatomic) EDODeviceDetector *detector;
 /** The connected device info of mappings from device serial strings to auto-assigned device IDs. */
-@property(nonatomic) NSMutableDictionary *deviceInfo;
+@property(nonatomic) NSMutableDictionary<NSString*, NSNumber*>  *deviceInfo;
 @end
 
 @implementation EDODeviceConnector {
@@ -69,7 +69,7 @@ static const int64_t kDeviceDetectTime = 2;
     // Wait for a short time to detect all connected devices when listening just starts.
     sleep(kDeviceDetectTime);
   }
-  __block NSArray *result;
+  __block NSArray<NSString*> *result;
   dispatch_sync(_syncQueue, ^{
     result = [self.deviceInfo.allKeys copy];
   });
@@ -153,7 +153,7 @@ static const int64_t kDeviceDetectTime = 2;
                                                       userInfo:userInfo];
   } else if ([messageType isEqualToString:kEDOMessageTypeDetachedKey]) {
     NSNumber *deviceID = packet[kEDOMessageDeviceIDKey];
-    NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
+    NSMutableArray<NSString*> *keysToRemove = [[NSMutableArray alloc] init];
     dispatch_sync(_syncQueue, ^{
       for (NSString *serialNumberString in self.deviceInfo) {
         if ([self.deviceInfo[serialNumberString] isEqualToNumber:deviceID]) {

--- a/Device/Tests/EDODeviceConnectorTest.m
+++ b/Device/Tests/EDODeviceConnectorTest.m
@@ -34,7 +34,7 @@ static NSString *const kFakeSerialNumber = @"fake_serial";
 // Exposes the internal property for test purpose.
 @interface EDODeviceConnector ()
 @property(nonatomic) EDODeviceDetector *detector;
-@property(nonatomic) NSMutableDictionary *deviceInfo;
+@property(nonatomic) NSMutableDictionary<NSString*, NSNumber*> *deviceInfo;
 @end
 
 @interface EDODeviceConnectorTest : XCTestCase

--- a/Service/Sources/EDOHostService+Handlers.m
+++ b/Service/Sources/EDOHostService+Handlers.m
@@ -31,7 +31,7 @@
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     handlers = [[NSMutableDictionary alloc] init];
-    NSArray *requestClasses = @[
+    NSArray<class> *requestClasses = @[
       [EDOClassRequest class],
       [EDOInvocationRequest class],
       [EDOMethodSignatureRequest class],

--- a/Service/Sources/EDOInvocationMessage.m
+++ b/Service/Sources/EDOInvocationMessage.m
@@ -212,7 +212,7 @@ static EDORemoteException *CreateRemoteException(id localException) {
                                           forKey:kEDOInvocationCoderReturnValueKey];
     _exception = [aDecoder decodeObjectOfClass:[EDORemoteException class]
                                         forKey:kEDOInvocationCoderExceptionKey];
-    NSSet *anyClasses =
+    NSSet<Class> *anyClasses =
         [NSSet setWithObjects:[EDOBlockObject class], [NSObject class], [EDOObject class], nil];
     _outValues = [aDecoder decodeObjectOfClasses:anyClasses forKey:kEDOInvocationCoderOutValuesKey];
   }
@@ -515,7 +515,7 @@ static EDORemoteException *CreateRemoteException(id localException) {
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
-    NSSet *anyClasses =
+    NSSet<Class> *anyClasses =
         [NSSet setWithObjects:[EDOBlockObject class], [EDOObject class], [NSObject class], nil];
     _target = [aDecoder decodeInt64ForKey:kEDOInvocationCoderTargetKey];
     _selectorName = [aDecoder decodeObjectOfClass:[NSString class]

--- a/Service/Sources/EDOParameter.m
+++ b/Service/Sources/EDOParameter.m
@@ -102,7 +102,7 @@ static NSString *const kEDOParameterCoderTypeKey = @"type";
     // EDOParameter can carry any type of object as long as it's serializable, so it whitelists all
     // the types inheriting from NSObject. EDOObject and EDOBlockObject are NSProxy's and need to be
     // whitelisted as well.
-    NSSet *anyClasses =
+    NSSet<Class> *anyClasses =
         [NSSet setWithObjects:[EDOBlockObject class], [EDOObject class], [NSObject class], nil];
     _value = [aDecoder decodeObjectOfClasses:anyClasses forKey:kEDOParameterCoderValueKey];
     _valueObjCType = [aDecoder decodeObjectOfClass:[NSString class]

--- a/Service/Tests/FunctionalTests/EDOServiceUIBlockTest.m
+++ b/Service/Tests/FunctionalTests/EDOServiceUIBlockTest.m
@@ -168,7 +168,7 @@
 - (void)testBlockByValueAndOutArgument {
   EDOTestDummy *remoteDummy = [EDOClientService rootObjectWithPort:EDOTEST_APP_SERVICE_PORT];
 
-  NSArray *arrayReturn = [remoteDummy returnWithBlockObject:^id(EDOTestDummy *dummy) {
+  NSArray<NSNumber*> *arrayReturn = [remoteDummy returnWithBlockObject:^id(EDOTestDummy *dummy) {
     // Use NSClassFromString to fetch EDOObject to make it private here.
     XCTAssertEqual([dummy class], NSClassFromString(@"EDOObject"));
     XCTAssertEqual(dummy.value, 10);

--- a/Service/Tests/FunctionalTests/EDOServiceUITest.m
+++ b/Service/Tests/FunctionalTests/EDOServiceUITest.m
@@ -401,8 +401,8 @@ static NSString *const kTestServiceName = @"com.google.edo.testService";
 - (void)testRemoteObjectCopy {
   [self launchApplicationWithPort:EDOTEST_APP_SERVICE_PORT initValue:5];
   EDOTestDummy *dummy = [EDOClientService rootObjectWithPort:EDOTEST_APP_SERVICE_PORT];
-  NSArray *remoteArray = [dummy returnArray];
-  NSArray *remoteArrayCopy;
+  NSArray<NSNumber*> *remoteArray = [dummy returnArray];
+  NSArra<NSNumber*>y *remoteArrayCopy;
   XCTAssertNoThrow(remoteArrayCopy = [remoteArray copy]);
   XCTAssertEqual(remoteArray, remoteArrayCopy);
 }
@@ -410,8 +410,8 @@ static NSString *const kTestServiceName = @"com.google.edo.testService";
 - (void)testRemoteObjectMutableCopy {
   [self launchApplicationWithPort:EDOTEST_APP_SERVICE_PORT initValue:5];
   EDOTestDummy *dummy = [EDOClientService rootObjectWithPort:EDOTEST_APP_SERVICE_PORT];
-  NSArray *remoteArray = [dummy returnArray];
-  NSMutableArray *remoteArrayCopy = [remoteArray mutableCopy];
+  NSArray<NSNumber*> *remoteArray = [dummy returnArray];
+  NSMutableArray<NSNumber*> *remoteArrayCopy = [remoteArray mutableCopy];
   XCTAssertNotEqual(remoteArray, remoteArrayCopy);
   XCTAssertEqualObjects(remoteArray, remoteArrayCopy);
   [remoteArrayCopy addObject:@"test"];

--- a/Service/Tests/PerfTests/EDOServicePerfTest.m
+++ b/Service/Tests/PerfTests/EDOServicePerfTest.m
@@ -194,7 +194,7 @@ static const size_t kNumOfBenchmarkExecutions = 100;
       assertPerformBlockWithWeight:1
                         executions:10
                              block:^(EDOTestDummy *remoteDummy) {
-                               NSArray *result = [[remoteDummy returnByValue] returnLargeArray];
+                               NSArray<NSNumber *>  *result = [[remoteDummy returnByValue] returnLargeArray];
                                for (NSInteger i = 0; i < 1000; i++) {
                                  XCTAssert(((NSNumber *)result[i]).integerValue == i);
                                }
@@ -203,7 +203,7 @@ static const size_t kNumOfBenchmarkExecutions = 100;
       [self assertPerformBlockWithWeight:1000
                               executions:10
                                    block:^(EDOTestDummy *remoteDummy) {
-                                     NSArray *result = [remoteDummy returnLargeArray];
+                                     NSArray<NSNumber *>  *result = [remoteDummy returnLargeArray];
                                      for (NSInteger i = 0; i < 1000; i++) {
                                        XCTAssert(((NSNumber *)result[i]).integerValue == i);
                                      }
@@ -212,7 +212,7 @@ static const size_t kNumOfBenchmarkExecutions = 100;
 }
 
 - (void)testIteratingPassByValueParameterLotsTimes {
-  NSMutableArray *array = [[NSMutableArray alloc] initWithCapacity:1000];
+  NSMutableArray<NSNumber *>  *array = [[NSMutableArray alloc] initWithCapacity:1000];
   for (int i = 0; i < 1000; i++) {
     [array addObject:@(i)];
   }

--- a/Service/Tests/TestsBundle/EDOTestDummy.h
+++ b/Service/Tests/TestsBundle/EDOTestDummy.h
@@ -123,8 +123,8 @@ typedef EDOTestDummy * (^EDOMultiTypesHandler)(EDOTestDummyStruct, int, id, EDOT
 - (BOOL)returnBoolWithError:(NSError **)errorOrNil;
 - (NSString *)returnClassNameWithObject:(id)object;
 - (NSInteger)returnCountWithArray:(NSArray *)value;
-- (NSInteger)returnSumWithArray:(NSArray *)value;
-- (NSInteger)returnSumWithArrayAndProxyCheck:(NSArray *)value;
+- (NSInteger)returnSumWithArray:(NSArray<NSNumber*> *)value;
+- (NSInteger)returnSumWithArrayAndProxyCheck:(NSArray<NSNumber*> *)value;
 - (int *)returnIntPointer;
 
 /**

--- a/Service/Tests/TestsBundle/EDOTestDummy.m
+++ b/Service/Tests/TestsBundle/EDOTestDummy.m
@@ -326,7 +326,7 @@ static const NSInteger kLargeArraySize = 1000;
   return value.count;
 }
 
-- (NSInteger)returnSumWithArray:(NSArray *)value {
+- (NSInteger)returnSumWithArray:(NSArray<NSNumber*> *)value {
   NSInteger result = 0;
   for (NSNumber *number in value) {
     result += number.integerValue;
@@ -334,7 +334,7 @@ static const NSInteger kLargeArraySize = 1000;
   return result;
 }
 
-- (NSInteger)returnSumWithArrayAndProxyCheck:(NSArray *)value {
+- (NSInteger)returnSumWithArrayAndProxyCheck:(NSArray<NSNumber*> *)value {
   NSAssert(!value.isProxy,
            @"This method is to test pass-by-value. The parameter should not be a proxy.");
   return [self returnSumWithArray:value];

--- a/Service/Tests/UnitTests/EDOServiceTest.m
+++ b/Service/Tests/UnitTests/EDOServiceTest.m
@@ -693,9 +693,9 @@ static NSString *const kTestServiceName = @"com.google.edotest.service";
 
 - (void)testEDOAsDictKey {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSSet *returnSet = [dummyOnBackground returnSet];
-  NSArray *returnArray = [dummyOnBackground returnArray];
-  NSMutableDictionary *dictionary = [[NSMutableDictionary alloc] init];
+  NSSet<NSNumber *>  *returnSet = [dummyOnBackground returnSet];
+  NSArray<NSNumber *>  *returnArray = [dummyOnBackground returnArray];
+  NSMutableDictionary<NSString *, NSNumber *>  *dictionary = [[NSMutableDictionary alloc] init];
 
   XCTAssertNil(dictionary[returnSet]);
   XCTAssertNoThrow(dictionary[returnSet] = @1);
@@ -707,8 +707,8 @@ static NSString *const kTestServiceName = @"com.google.edotest.service";
 
 - (void)testEDOAsCFDictKey {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSSet *returnSet = [dummyOnBackground returnSet];
-  NSArray *returnArray = [dummyOnBackground returnArray];
+  NSSet<NSNumber *> *returnSet = [dummyOnBackground returnSet];
+  NSArray<NSNumber *> *returnArray = [dummyOnBackground returnArray];
   CFMutableDictionaryRef cfDictionary = CFDictionaryCreateMutable(
       NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 
@@ -751,8 +751,8 @@ static NSString *const kTestServiceName = @"com.google.edotest.service";
 
 - (void)testEDOReturnsAsValueType {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSArray *returnArray = [[dummyOnBackground returnByValue] returnArray];
-  NSArray *localArray = @[ @1, @2, @3, @4 ];
+  NSArray<NSNumber *> *returnArray = [[dummyOnBackground returnByValue] returnArray];
+  NSArray<NSNumber *> *localArray = @[ @1, @2, @3, @4 ];
   XCTAssertEqual([returnArray class], [localArray class]);
   XCTAssertTrue([returnArray isEqualToArray:localArray]);
 }
@@ -771,25 +771,25 @@ static NSString *const kTestServiceName = @"com.google.edotest.service";
 
 - (void)testEDOPassByValueWithRemoteObject {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSArray *array = [dummyOnBackground returnArray];
+  NSArray<NSNumber *> *array = [dummyOnBackground returnArray];
   XCTAssertEqual([dummyOnBackground returnCountWithArray:[array passByValue]], 4);
 }
 
 - (void)testEDOPassByValueNestedWithReturnByValue {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSArray *array = [dummyOnBackground returnArray];
+  NSArray<NSNumber *> *array = [dummyOnBackground returnArray];
   XCTAssertEqual([dummyOnBackground returnCountWithArray:[[array returnByValue] passByValue]], 4);
 }
 
 - (void)testEDOPassByValueNestedWithPassByValue {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSArray *array = [dummyOnBackground returnArray];
+  NSArray<NSNumber *> *array = [dummyOnBackground returnArray];
   XCTAssertEqual([dummyOnBackground returnCountWithArray:[[array passByValue] passByValue]], 4);
 }
 
 - (void)testEDOReturnByValueNestedWithPassByValue {
   EDOTestDummy *dummyOnBackground = self.rootObjectOnBackground;
-  NSArray *array = [dummyOnBackground returnArray];
+  NSArray<NSNumber *> *array = [dummyOnBackground returnArray];
   XCTAssertEqual([dummyOnBackground returnCountWithArray:[[array passByValue] returnByValue]], 4);
 }
 


### PR DESCRIPTION
Some can not be easily typed, such as list of arguments.

This help the reader understands what they can expect in a collection.


I have not been able to test it because I get 

>Cannot code sign because the target does not have an Info.plist file and one is not being generated automatically. Apply an Info.plist file to the target using the INFOPLIST_FILE build setting or generate one automatically by setting the GENERATE_INFOPLIST_FILE build setting to YES (recommended).

when I try to build it or run the test suite, I’d be happy to get help here please