### PR TITLE
Set QoS to USER_INTERACTIVE for socket queues

### DIFF
--- a/Channel/Sources/EDOSocket.m
+++ b/Channel/Sources/EDOSocket.m
@@ -175,7 +175,8 @@ static void edo_RunHandlerWithErrorInQueueWithBlock(int code, dispatch_queue_t q
                      queue:(dispatch_queue_t)queue
             connectedBlock:(EDOSocketConnectedBlock)block {
   block = block ?: gNoOpHandlerBlock;
-  queue = queue ?: dispatch_queue_create("com.google.edo.connectSocket", DISPATCH_QUEUE_SERIAL);
+  dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class( DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
+  queue = queue ?: dispatch_queue_create("com.google.edo.connectSocket", queueAttributes);
 
   int socketErr = 0;
   dispatch_fd_t socketFD = edo_CreateSocket(&socketErr);

--- a/Channel/Sources/EDOSocketChannel.m
+++ b/Channel/Sources/EDOSocketChannel.m
@@ -62,8 +62,9 @@
   if (self) {
     // For internal IO and event handlers, it is equivalent to creating it as a serial queue as they
     // are not reentrant and only one block will be scheduled by dispatch io and dispatch source.
+    dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class( DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
     _handlerQueue =
-        dispatch_queue_create("com.google.edo.socketChannel.handler", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_create("com.google.edo.socketChannel.handler", queueAttributes);
   }
   return self;
 }


### PR DESCRIPTION
The dispatch queues for socket connection and channel handling were
created with the default Quality of Service (QoS) class. This can
lead to priority inversion, where critical eDO communication is
delayed by lower-priority background tasks, causing UI
unresponsiveness or test flakiness.

This change explicitly sets the QoS for these queues to
`QOS_CLASS_USER_INTERACTIVE`. This ensures that work scheduled on these
queues is given high priority by the system, improving the
responsiveness and reliability of eDO-based communication.